### PR TITLE
:construction_worker: fix ci, cd

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -15,11 +15,11 @@ jobs:
         rust: [stable]
         include:
           - os: macos-latest
-            artifact_prefix: macOS
+            artifact_prefix: macos-x86_64
             target: x86_64-apple-darwin
             binary_postfix: ""
           - os: macos-13-arm64
-            artifact_prefix: macOS
+            artifact_prefix: macos-arm64
             target: aarch64-apple-darwin
             binary_postfix: ""
           - os: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cipher"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "aes",
  "base64",
@@ -173,9 +173,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "config"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
- "cipher 0.1.0",
+ "cipher 0.0.1",
  "once_cell",
  "rand",
  "rand_chacha",

--- a/cipher/Cargo.toml
+++ b/cipher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/cmd/Cargo.toml
+++ b/cmd/Cargo.toml
@@ -15,5 +15,5 @@ test = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-config = { path = "../config" }
+config = { path = "../config", version = "0.0.1" }
 clap = { version = "4.4.12", features = ["derive"] }

--- a/config/Cargo.toml
+++ b/config/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "config"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 [dependencies]
-cipher = { path = "../cipher" }
+cipher = { path = "../cipher", version = "0.0.1" }
 
 serde_yaml = "0.9.29"
 thiserror = "1.0.52"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Continuous Deployment workflow to differentiate artifacts for macOS builds by architecture (x86_64 and arm64).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->